### PR TITLE
bump maxscale version to 2.5

### DIFF
--- a/maxscale/docker-compose.yml
+++ b/maxscale/docker-compose.yml
@@ -35,14 +35,17 @@ services:
             - "4003:3306"
 
     maxscale:
-        image: mariadb/maxscale:2.4
+        image: mariadb/maxscale:2.5
         depends_on:
             - master
             - slave1
             - slave2
         volumes:
             - ./maxscale.cnf.d:/etc/maxscale.cnf.d
+            - ./maxscale.cnf:/etc/maxscale.cnf
         ports:
             - "4006:4006"  # readwrite port
             - "4008:4008"  # readonly port
             - "8989:8989"  # REST API port
+        restart: on-failure
+


### PR DESCRIPTION
- bump maxscale version to 2.5
- include main config to docker volume
- enable restart on maxscale failed to start

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
